### PR TITLE
Replacing space with %20

### DIFF
--- a/fastapi_discord/client.py
+++ b/fastapi_discord/client.py
@@ -25,7 +25,7 @@ class DiscordOAuthClient:
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
-        self.scopes = ' '.join(scope for scope in scopes)
+        self.scopes = '%20'.join(scope for scope in scopes)
 
     @property
     def oauth_login_url(self):


### PR DESCRIPTION
Although previous works as expected because browser parse it in URL, in case of direct opening the link from the response JSON it opens incomplete URL (till the first appearance of space)