### PR TITLE
Added Refresh Token support

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -42,6 +42,15 @@ async def auth(request: Request):
         return 'False'
 
 
+@app.get('/refresh')
+async def refresh(refresh_token: str):
+    token, refresh_token = await discord.refresh_access_token(refresh_token)
+    return {
+        "access_token": token,
+        "refresh_token": refresh_token
+    }
+
+
 @app.exception_handler(Unauthorized)
 async def unauthorized_error_handler(request: Request, e: Unauthorized):
     return JSONResponse({

--- a/fastapi_discord/client.py
+++ b/fastapi_discord/client.py
@@ -75,6 +75,18 @@ class DiscordOAuthClient:
                 resp = await resp.json()
                 return resp.get('access_token'), resp.get('refresh_token')
 
+    async def refresh_access_token(self, refresh_token: str):
+        payload = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(DISCORD_TOKEN_URL, data=payload) as resp:
+                resp = await resp.json()
+                return resp.get('access_token'), resp.get('refresh_token')
+
     async def user(self, request: Request):
         route = '/users/@me'
         token = self.get_token(request)


### PR DESCRIPTION
I added refresh_access_token to the DiscordOAuthClient.

It accepts a single parameter, refresh_token, and will return a new access_token and refresh_token.

Useful for if your access_token has expired but your refresh token is still good.